### PR TITLE
include gcskeyfile for stackdriver log

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ ENV NODE_SOURCE /usr/src/
 WORKDIR $NODE_SOURCE
 
 COPY config.js /config.js
+COPY gcskeyfile.json /gcskeyfile.json
 
 RUN set -x \
 	&& apt-get update \
@@ -26,6 +27,7 @@ RUN buildDeps=' \
 	&& cd plate-vue \
 	&& git pull \
 	&& cp /config.js ./api/ \
+	&& cp /gcskeyfile.json ./gcskeyfile.json \
 	&& cp -rf . .. \
 	&& cd .. \
 	&& rm -rf plate-vue \


### PR DESCRIPTION
gcskeyfile is necessary for stackdriver log writting. It must be included during docker building